### PR TITLE
Quiz output functionality

### DIFF
--- a/components/quiz/QuizCard.js
+++ b/components/quiz/QuizCard.js
@@ -98,7 +98,13 @@ export default class QuizCard extends React.Component {
         </Response_Radio>
     }
     else if (this.props.quiz.questions[this.state.quizIndex].type == "scale") {
-      responseComponent = <Response_Scale></Response_Scale>
+      responseComponent =
+        <Response_Scale
+          scaleLow={this.props.quiz.questions[this.state.quizIndex].scaleLow}
+          scaleHigh={this.props.quiz.questions[this.state.quizIndex].scaleHigh}
+          onChange={this.updateQuizData}
+          value={this.state.quizData[this.state.quizIndex]}
+        ></Response_Scale>
       buttonDisabled = false;
     }
     else if (this.props.quiz.questions[this.state.quizIndex].type == "text") {

--- a/components/quiz/Response_Checkbox.js
+++ b/components/quiz/Response_Checkbox.js
@@ -3,21 +3,33 @@ import { Text, View, StyleSheet, ImagePropTypes } from 'react-native';
 import { Checkbox } from 'react-native-paper';
 
 export default function Response_Checkbox(props) {
-  let handleChecked = (score) => {
+  const onChange = (score) => {
+    let oldValue = Array.isArray(props.value) ? [...props.value] : [];
     let newValue = [];
+    let flags = {};
     // Handle "uncheck" case
-    if (Array.isArray(props.value) && props.value.indexOf(score) >= 0) {
-      let i = props.value.indexOf(score);
-      newValue = props.value.splice(i, 1);
-    }
+    if (oldValue.length > 0 && oldValue.indexOf(score) >= 0) {
+      oldValue.splice(oldValue.indexOf(score), 1);
+      newValue = oldValue.splice(0);
     // Handle "check" case
-    if (Array.isArray(props.value)) {
-      newValue = [...props.value, score];
     } else {
-      newValue = [score];
+      newValue = [...oldValue, score];
     }
-
-    props.onChange(newValue);
+    // Get flag changes
+    for (const key in props.responses) {
+      if (newValue.includes(props.responses[key].score)) {
+        for (const flagKey in props.responses[key].flagChanges) {
+          // When flags compound within the same question
+          if (Object.keys(flags).includes(flagKey)) {
+            flags[flagKey] = parseFloat(flags[flagKey]) + parseFloat(props.responses[key].flagChanges[flagKey]);
+          // Otherwise, add normally
+          } else {
+            flags[flagKey] = parseFloat(props.responses[key].flagChanges[flagKey]);
+          }
+        }
+      }
+    }
+    props.onChange(newValue, flags);
   }
 
   return (
@@ -29,7 +41,7 @@ export default function Response_Checkbox(props) {
             <Checkbox
               key={key}
               status={Array.isArray(props.value) && props.value.indexOf(item.score) >= 0 ? 'checked' : 'unchecked'}
-              onPress={() => {handleChecked(item.score)}}
+              onPress={() => onChange(item.score)}
             />
           </View>
         )

--- a/components/quiz/Response_Radio.js
+++ b/components/quiz/Response_Radio.js
@@ -3,9 +3,19 @@ import { Text, View, StyleSheet } from 'react-native';
 import { RadioButton } from 'react-native-paper';
 
 export default function Response_Radio(props) {
+  const onChange = (value) => {
+    let flags = {};
+    for (const key in props.responses) {
+      if (props.responses[key].score == value) {
+        flags = {...props.responses[key].flagChanges};
+        break;
+      }
+    }
+    props.onChange(value, flags);
+  }
   return (
     <View style={styles.quizQuestion}>
-      <RadioButton.Group onValueChange={value => props.onChange(value)} value={props.value}>
+      <RadioButton.Group onValueChange={value => onChange(value)} value={props.value}>
         {
           // TODO: Use RadioButton.Item
           Object.values(props.responses).map((item, key) =>

--- a/components/quiz/Response_Scale.js
+++ b/components/quiz/Response_Scale.js
@@ -1,16 +1,44 @@
 import * as React from 'react';
 import {Text, View, StyleSheet} from 'react-native';
+import { RadioButton } from 'react-native-paper';
 
 export default function Response_Scale(props){
+  // TODO: The following is a temporary solution, eventually we'll want to use an actual scale element
+  let options = [];
+  let scaleLow = props.scaleLow || 0;
+  for (let i = scaleLow; i < props.scaleHigh + 1; i += 1) {
+    options.push(i);
+  }
   return(
     <View style={styles.quizQuestion}>
+      <RadioButton.Group onValueChange={value => props.onChange(value)} value={props.value}>
+        {
+          // TODO: Use RadioButton.Item
+         options.map((item, key) =>
+            <View style={styles.checkItem} key={key}>
+              <RadioButton
+                value={item}
+                status={props.value === item ? 'checked' : 'unchecked'}
+              />
+              <Text style={styles.checkText}>{item}</Text>
+            </View>
+          )
+        }
+      </RadioButton.Group>
     </View>
   );
 }
 
 const styles = StyleSheet.create({
-  text:{
-    color: "#fff",
+  text: {
+    color: "#48484A",
     textAlign: "center"
+  },
+  checkItem: {
+    flexDirection: "row",
+    alignSelf: "center"
+  },
+  checkText: {
+    marginTop: 10
   }
 });

--- a/components/quiz/Response_Scale.js
+++ b/components/quiz/Response_Scale.js
@@ -5,16 +5,28 @@ import { RadioButton } from 'react-native-paper';
 export default function Response_Scale(props){
   // TODO: The following is a temporary solution, eventually we'll want to use an actual scale element
   let options = [];
-  let scaleLow = props.scaleLow || 0;
+  let scaleLow = props.scaleLow || 1;
   for (let i = scaleLow; i < props.scaleHigh + 1; i += 1) {
     options.push(i);
   }
+
+  const onChange = (value) => {
+    let flags = {};
+    for (const key in props.flagChanges) {
+      if (key == value) {
+        flags = {...props.flagChanges[key]};
+        break;
+      }
+    }
+    props.onChange(value, flags);
+  }
+
   return(
     <View style={styles.quizQuestion}>
-      <RadioButton.Group onValueChange={value => props.onChange(value)} value={props.value}>
+      <RadioButton.Group onValueChange={value => onChange(value)} value={props.value}>
         {
           // TODO: Use RadioButton.Item
-         options.map((item, key) =>
+          options.map((item, key) =>
             <View style={styles.checkItem} key={key}>
               <RadioButton
                 value={item}

--- a/screens/Login.js
+++ b/screens/Login.js
@@ -19,13 +19,14 @@ export default class Login extends React.Component {
     // TODO: Firebase stuff...
     console.log('handleLogin');
     firebase.auth().signInWithEmailAndPassword(this.state.email, this.state.password)
-    .catch(error => this.setState({ errorMessage: error.message }))
+    .catch(error => this.setState({ errorMessage: error.message }));
   }
   render() {
     return (
       <View style={styles.container}>
         <Text style={styles.header}>Login</Text>
-        {this.state.errorMessage &&
+        {/* Adding !! to try to fix issue #31... expected: login page does not crash */}
+        {!!this.state.errorMessage &&
           <Text style={{ color: 'red' }}>
             {this.state.errorMessage}
           </Text>


### PR DESCRIPTION
Major update that provides functionality for quiz outputs. When a user takes a quiz (the incident quiz only, for now) each scripted response (radio, checkbox, and scale) yields a "flag" change. These flag changes are gathered up and summed when the quiz is submitted. When one "flag" scores higher than the others, that should give us an idea of what we want to suggest to the user.

Results for quizzes are stored in the user's folder in firebase, under `profile/quizHistory/<name-of-quiz>`. Here, the timestamp of when the quiz was submitted, what responses were selected (this is not useable data right now, but may be in future), and the `outputFlags` are stored.