### PR TITLE
Cleaned up quiz design, using IDs

### DIFF
--- a/components/quiz/QuizCard.js
+++ b/components/quiz/QuizCard.js
@@ -42,6 +42,7 @@ export default class QuizCard extends React.Component {
       flagUpdate[state.quizIndex] = flags;
       return { quizData: dataUpdate, quizFlags: flagUpdate };
     });
+    console.log(data, flags);
   }
 
   handleNextQuestion = () => {

--- a/components/quiz/Response_Checkbox.js
+++ b/components/quiz/Response_Checkbox.js
@@ -1,25 +1,23 @@
 import * as React from 'react';
-import { TouchableOpacity } from 'react-native';
-import { Text, View, StyleSheet, ImagePropTypes } from 'react-native';
+import { Text, View, StyleSheet } from 'react-native';
 import { Checkbox } from 'react-native-paper';
-import { RFValue } from "react-native-responsive-fontsize";
 
 export default function Response_Checkbox(props) {
-  const onChange = (score) => {
+  const onChange = (id) => {
     let oldValue = Array.isArray(props.value) ? [...props.value] : [];
     let newValue = [];
     let flags = {};
     // Handle "uncheck" case
-    if (oldValue.length > 0 && oldValue.indexOf(score) >= 0) {
-      oldValue.splice(oldValue.indexOf(score), 1);
+    if (oldValue.length > 0 && oldValue.indexOf(id) >= 0) {
+      oldValue.splice(oldValue.indexOf(id), 1);
       newValue = oldValue.splice(0);
       // Handle "check" case
     } else {
-      newValue = [...oldValue, score];
+      newValue = [...oldValue, id];
     }
     // Get flag changes
     for (const key in props.responses) {
-      if (newValue.includes(props.responses[key].score)) {
+      if (newValue.includes(props.responses[key].id)) {
         for (const flagKey in props.responses[key].flagChanges) {
           // When flags compound within the same question
           if (Object.keys(flags).includes(flagKey)) {
@@ -38,21 +36,16 @@ export default function Response_Checkbox(props) {
     <View>
       {
         Object.values(props.responses).map((item, key) =>
-          <TouchableOpacity
-            style={styles.checkBoxDesign}
-            onPress={() => onChange(item.score)}
+          <Checkbox.Item
+            label={item.text}
+            // TODO: This is not working at the moment... look for an update eventually
+            labelStyle={{color: '#00095e'}}
+            style={styles.checkBox}
+            color="#00095e"
             key={key}
-          >
-            <View style={styles.checkItem}>
-              <Checkbox
-                style={styles.checkBox}
-                key={key}
-                status={Array.isArray(props.value) && props.value.indexOf(item.score) >= 0 ? 'checked' : 'unchecked'}
-                onPress={() => onChange(item.score)}
-              />
-              <Text style={styles.checkText}>{item.text}</Text>
-            </View>
-          </TouchableOpacity>
+            status={Array.isArray(props.value) && props.value.indexOf(item.id) >= 0 ? 'checked' : 'unchecked'}
+            onPress={() => onChange(item.id)}
+          />
         )
       }
     </View>
@@ -60,37 +53,11 @@ export default function Response_Checkbox(props) {
 }
 
 const styles = StyleSheet.create({
-  text: {
-    color: "#48484A",
-    textAlign: "center"
-  },
-  checkItem: {
-    marginTop: '1.2%',
-    flexDirection: "row",
-    alignSelf: "center",
-    right: '28%'
-  },
   checkBox: {
-    flex: 1,
-    flexDirection: 'row',
-    position: 'absolute',
-  },
-  checkText: {
-    marginTop: 7,
-    color: '#00095e',
-    fontFamily: 'Poppins-Medium',
-    fontSize: 15,
-    fontWeight: 'bold',
-  },
-  checkBoxDesign: {
-    marginTop: 15,
-    borderWidth: 2,
-    alignSelf: "center",
-    borderColor: 'white',
+    marginBottom: '10px',
     backgroundColor: 'white',
-    borderRadius: 20,
-    overflow: 'hidden',
-    height: RFValue(40),
-    width: RFValue(260), //260
-  },
+    borderRadius: '10px',
+    alignSelf: 'center',
+    width: '80%'
+  }
 });

--- a/components/quiz/Response_Checkbox.js
+++ b/components/quiz/Response_Checkbox.js
@@ -54,9 +54,9 @@ export default function Response_Checkbox(props) {
 
 const styles = StyleSheet.create({
   checkBox: {
-    marginBottom: '10px',
+    marginBottom: 10,
     backgroundColor: 'white',
-    borderRadius: '10px',
+    borderRadius: 10,
     alignSelf: 'center',
     width: '80%'
   }

--- a/components/quiz/Response_Radio.js
+++ b/components/quiz/Response_Radio.js
@@ -35,9 +35,9 @@ export default function Response_Radio(props) {
 
 const styles = StyleSheet.create({
   radioButton: {
-    marginBottom: '10px',
+    marginBottom: 10,
     backgroundColor: 'white',
-    borderRadius: '10px',
+    borderRadius: 10,
     alignSelf: 'center',
     width: '80%'
   },

--- a/components/quiz/Response_Radio.js
+++ b/components/quiz/Response_Radio.js
@@ -1,13 +1,12 @@
 import * as React from 'react';
 import { Text, View, StyleSheet, TouchableOpacity } from 'react-native';
 import { RadioButton } from 'react-native-paper';
-import { RFValue } from "react-native-responsive-fontsize";
 
 export default function Response_Radio(props) {
   const onChange = (value) => {
     let flags = {};
     for (const key in props.responses) {
-      if (props.responses[key].score == value) {
+      if (props.responses[key].id == value) {
         flags = { ...props.responses[key].flagChanges };
         break;
       }
@@ -15,25 +14,18 @@ export default function Response_Radio(props) {
     props.onChange(value, flags);
   }
   return (
-    <View style={styles.quizQuestion}>
+    <View>
       <RadioButton.Group onValueChange={value => onChange(value)} value={props.value}>
         {
-          // TODO: Use RadioButton.Item
           Object.values(props.responses).map((item, key) =>
-            <TouchableOpacity
-              style={styles.checkBoxDesign}
-              onPress={value => onChange(item.score)}
+            <RadioButton.Item
+              label={item.text}
+              labelStyle={{color: '#00095e'}}
+              style={styles.radioButton}
+              color="#00095e"
+              value={item.id}
               key={key}
-            >
-              <View style={styles.checkItem}>
-                <RadioButton
-                  value={item.score}
-                  status={props.value === item.score ? 'checked' : 'unchecked'}
-                />
-                <Text style={styles.checkText}>{item.text}</Text>
-              </View>
-
-            </TouchableOpacity>
+            />
           )
         }
       </RadioButton.Group>
@@ -42,29 +34,11 @@ export default function Response_Radio(props) {
 }
 
 const styles = StyleSheet.create({
-  text: {
-    color: "#48484A",
-    textAlign: "center"
-  },
-  checkItem: {
-    marginTop: '1.2%',
-    flexDirection: "row",
-    alignSelf: "center",
-    right: '28%'
-  },
-  checkText: {
-    marginTop: 10,
-    color: '#00095e'
-  },
-  checkBoxDesign: {
-    marginTop: 15,
-    borderWidth: 2,
-    alignSelf: "center",
-    borderColor: 'white',
+  radioButton: {
+    marginBottom: '10px',
     backgroundColor: 'white',
-    borderRadius: 20,
-    overflow: 'hidden',
-    height: RFValue(40),
-    width: RFValue(260), //260
+    borderRadius: '10px',
+    alignSelf: 'center',
+    width: '80%'
   },
 });

--- a/components/quiz/Response_Scale.js
+++ b/components/quiz/Response_Scale.js
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import {Text, View, StyleSheet, TouchableOpacity} from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { RadioButton } from 'react-native-paper';
-import { RFValue } from "react-native-responsive-fontsize";
 
 export default function Response_Scale(props){
   // TODO: The following is a temporary solution, eventually we'll want to use an actual scale element
@@ -26,21 +25,15 @@ export default function Response_Scale(props){
     <View style={styles.quizQuestion}>
       <RadioButton.Group onValueChange={value => onChange(value)} value={props.value}>
         {
-          // TODO: Use RadioButton.Item
           options.map((item, key) =>
-          <TouchableOpacity 
-            style = {styles.checkBoxDesign}
-            onPress={value => onChange(item)}
-            key={key}
-          >
-            <View style={styles.checkItem}>
-              <RadioButton
-                value={item}
-                status={props.value === item ? 'checked' : 'unchecked'}
-              />
-              <Text style={styles.checkText}>{item}</Text>
-            </View>
-          </TouchableOpacity>
+            <RadioButton.Item
+              label={item}
+              labelStyle={{color: '#00095e'}}
+              style={styles.radioButton}
+              color="#00095e"
+              value={item}
+              key={key}
+            />
           )
         }
       </RadioButton.Group>
@@ -49,29 +42,11 @@ export default function Response_Scale(props){
 }
 
 const styles = StyleSheet.create({
-  text: {
-    color: "#48484A",
-    textAlign: "center"
-  },
-  checkItem: {
-    marginTop: '1.2%',
-    flexDirection: "row",
-    alignSelf: "center",
-    right: '28%%'
-  },
-  checkText: {
-    marginTop: 10,
-    color: 'black',
-  },
-  checkBoxDesign: {
-    marginTop: 15,
-    borderWidth: 2,
-    alignSelf: "center",
-    borderColor: 'white',
+  radioButton: {
+    marginBottom: '10px',
     backgroundColor: 'white',
-    borderRadius: 20,
-    overflow: 'hidden',
-    height: RFValue(40),
-    width: RFValue(260), //260
+    borderRadius: '10px',
+    alignSelf: 'center',
+    width: '80%'
   },
 });

--- a/components/quiz/Response_Scale.js
+++ b/components/quiz/Response_Scale.js
@@ -43,9 +43,9 @@ export default function Response_Scale(props){
 
 const styles = StyleSheet.create({
   radioButton: {
-    marginBottom: '10px',
+    marginBottom: 10,
     backgroundColor: 'white',
-    borderRadius: '10px',
+    borderRadius: 10,
     alignSelf: 'center',
     width: '80%'
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19968,13 +19968,13 @@
       "integrity": "sha512-yN/jaDwmkv6osx4shi48Oi/QvVc1/gX+HbpFwRffV0FF+t8SQeYTBc+F4brJtpRkcYyeCNux2wZ33NF+b6HR8A=="
     },
     "react-native-paper": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/react-native-paper/-/react-native-paper-3.8.0.tgz",
-      "integrity": "sha512-3oNHjhjhpi/UDbYwwgeWQKf1qRbqQ7aTO0EUHbcxPNEq5BLClpI3kBoS6JTKk4Ge86xeJikXHHXN953g1mVr3Q==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/react-native-paper/-/react-native-paper-3.12.0.tgz",
+      "integrity": "sha512-c5GfDkITfrutoVB4+pE/kL2gH7sHuxD9eAs8+cY1q4PjuYW8geV1Hst14HQstSrYkksXN9StI0wryyb21BDfrw==",
       "requires": {
         "@callstack/react-theme-provider": "^3.0.5",
         "color": "^3.1.2",
-        "react-native-safe-area-view": "^0.14.6"
+        "react-native-safe-area-view": "^0.14.9"
       }
     },
     "react-native-reanimated": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "react-native-gesture-handler": "~1.6.0",
     "react-native-material-cards": "^1.0.15",
     "react-native-modern-header": "^0.1.0",
-    "react-native-paper": "^3.8.0",
+    "react-native-paper": "^3.12.0",
     "react-native-reanimated": "~1.9.0",
     "react-native-redash": "^15.11.1",
     "react-native-responsive-fontsize": "^0.4.3",


### PR DESCRIPTION
I changed a few quiz components to reflect a back-end data change (was using 'score' as if it were an ID, now we actualy have IDs for each response).

Also updated the style of the quiz. It's simpler now, using react-native-paper's RadioButton.Item and Checkbox.Item components. There is a slight bug in the Checkbox.Item, which should be included in their 3.13 release when it comes out in a few months.