### PR TITLE
Change AsyncStorage references to new package

### DIFF
--- a/App.js
+++ b/App.js
@@ -32,7 +32,7 @@ import NotificationsScreen from './screens/account/NotificationsScreen';
 import WelcomeTutorial from './screens/WelcomeTutorial';
 import BadgeScreen from './screens/account/BadgeScreen';
 
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import AdminPanel from './components/admin/AdminPanel';
 import AppIcons from './components/AppIcons';
 

--- a/components/Spotify/SpotifyPlaylist.js
+++ b/components/Spotify/SpotifyPlaylist.js
@@ -4,8 +4,8 @@
 */
 
 import * as React from 'react';
-import { StyleSheet, View, Text, AsyncStorage, Image } from 'react-native';
-
+import { StyleSheet, View, Text, Image } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import SpotifyWebAPI from 'spotify-web-api-js';
 import { AuthContext } from '../../AuthContext';
 import { RFValue } from 'react-native-responsive-fontsize';

--- a/screens/WelcomeScreen.js
+++ b/screens/WelcomeScreen.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, StyleSheet, Text, Image, Button, AsyncStorage, ScrollView } from 'react-native';
+import { View, StyleSheet, Text, Image, Button, ScrollView } from 'react-native';
 import firebase from '../Firebase.js';
 import { AuthContext } from '../AuthContext.js';
 import Swiper from 'react-native-swiper/src';

--- a/screens/account/AccountSummary.js
+++ b/screens/account/AccountSummary.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, StyleSheet, Text, Image, Button, AsyncStorage, ScrollView, TouchableOpacity } from 'react-native';
+import { View, StyleSheet, Text, Image, Button, ScrollView, TouchableOpacity } from 'react-native';
 import firebase from '../../Firebase.js';
 import { AuthContext } from '../../AuthContext.js';
 import SpotifyAuthButton from '../../spotify/SpotifyAuthButton';

--- a/screens/account/AccountTraits.js
+++ b/screens/account/AccountTraits.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, StyleSheet, Text, Image, Button, AsyncStorage, ScrollView } from 'react-native';
+import { View, StyleSheet, Text, Image, Button, ScrollView } from 'react-native';
 import firebase from '../../Firebase.js';
 import h from '../../globals';
 import { AuthContext } from '../../AuthContext.js';

--- a/screens/account/BadgeScreen.js
+++ b/screens/account/BadgeScreen.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, StyleSheet, Text, Image, Button, AsyncStorage, ScrollView } from 'react-native';
+import { View, StyleSheet, Text, Image, Button, ScrollView } from 'react-native';
 import firebase from '../../Firebase.js';
 import h from '../../globals';
 import { AuthContext } from '../../AuthContext.js';

--- a/screens/account/NotificationsScreen.js
+++ b/screens/account/NotificationsScreen.js
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { View, StyleSheet, Text, Image, Button, AsyncStorage, ScrollView } from 'react-native';
+import { View, StyleSheet, Text, Image, Button, ScrollView } from 'react-native';
 import firebase from '../../Firebase.js';
 import { AuthContext } from '../../AuthContext.js';
 

--- a/spotify/SpotifyAuthButton.js
+++ b/spotify/SpotifyAuthButton.js
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as WebBrowser from 'expo-web-browser';
 import { makeRedirectUri, ResponseType, useAuthRequest } from 'expo-auth-session';
 import { Button } from 'react-native';
-import { AsyncStorage } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { AuthContext } from '../AuthContext';
 
 WebBrowser.maybeCompleteAuthSession();


### PR DESCRIPTION
We are now using a new package for AsyncStorage since the one from React Native has been depreciated. It uses the same syntax, just a new import statement. Learn more here https://react-native-async-storage.github.io/async-storage/docs/usage

This will close issue #47 